### PR TITLE
fix: clamp negative precision in Encode to avoid panic

### DIFF
--- a/geohash.go
+++ b/geohash.go
@@ -50,12 +50,7 @@ const encodeMaxPrecision = 32
 //
 // The maximum supported precision is 32.
 func Encode(lat, lon float64, precision int) string {
-	if precision < 0 {
-		precision = 0
-	}
-	if precision > encodeMaxPrecision {
-		precision = encodeMaxPrecision
-	}
+	precision = min(max(precision, 0), encodeMaxPrecision)
 	var buf [encodeMaxPrecision]byte
 	box := defaultBox
 	even := true

--- a/geohash.go
+++ b/geohash.go
@@ -50,6 +50,9 @@ const encodeMaxPrecision = 32
 //
 // The maximum supported precision is 32.
 func Encode(lat, lon float64, precision int) string {
+	if precision < 0 {
+		precision = 0
+	}
 	if precision > encodeMaxPrecision {
 		precision = encodeMaxPrecision
 	}

--- a/geohash_test.go
+++ b/geohash_test.go
@@ -28,6 +28,18 @@ func TestEncodeMaxPrecision(t *testing.T) {
 	assert.StringLen(t, gh, encodeMaxPrecision)
 }
 
+func TestEncodePrecisionZero(t *testing.T) {
+	gh := Encode(testPoint.Lat, testPoint.Lon, 0)
+	assert.Equal(t, gh, "")
+}
+
+func TestEncodePrecisionNegative(t *testing.T) {
+	for _, precision := range []int{-1, -10, -100} {
+		gh := Encode(testPoint.Lat, testPoint.Lon, precision)
+		assert.Equal(t, gh, "")
+	}
+}
+
 func TestDecode(t *testing.T) {
 	box, err := Decode(testGeohash)
 	assert.NoError(t, err)


### PR DESCRIPTION
## Problem

`Encode` only clamped precision above `encodeMaxPrecision`, so a negative `precision` (public API) caused a panic on `buf[:precision]` (negative slice index):

```
runtime error: slice bounds out of range [:-1]
```

Refs: geohash.go:53-55,81

## Fix

Clamp negative `precision` to `0`, returning an empty string. This is consistent with the existing behavior of `precision == 0` (which already returns `""`), and matches the existing upper-bound clamping pattern for `precision > encodeMaxPrecision`.

## Tests

Added `TestEncodePrecisionZero` and `TestEncodePrecisionNegative` (covering `-1`, `-10`, `-100`). `make all` passes (build, test, lint: 0 issues) and `Encode` has 100% statement coverage.