### PR TITLE
docs: document Decode empty string behavior

### DIFF
--- a/geohash.go
+++ b/geohash.go
@@ -80,6 +80,8 @@ func Encode(lat, lon float64, precision int) string {
 }
 
 // Decode decodes a geohash to a [Box].
+//
+// An empty geohash returns the whole-world box (latitude -90 to 90, longitude -180 to 180) with a nil error.
 func Decode(gh string) (Box, error) {
 	box := defaultBox
 	even := true

--- a/geohash_test.go
+++ b/geohash_test.go
@@ -51,6 +51,12 @@ func TestDecodeInvalidCharacter(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestDecodeEmpty(t *testing.T) {
+	box, err := Decode("")
+	assert.NoError(t, err)
+	assert.Equal(t, box, defaultBox)
+}
+
 func TestBoxCenter(t *testing.T) {
 	box := Box{
 		Lat: Range{


### PR DESCRIPTION
Decode("") returns the whole-world defaultBox (lat -90 to 90, lon -180 to 180) with a nil error, which is surprising. Changing it to return an error would be a breaking API change, so this documents the existing behavior and adds a test to lock it in.