### PR TITLE
docs: document Encode behavior for precision <= 0

### DIFF
--- a/geohash.go
+++ b/geohash.go
@@ -49,6 +49,8 @@ const encodeMaxPrecision = 32
 // Encode encodes a location to a geohash.
 //
 // The maximum supported precision is 32.
+//
+// If precision is less than or equal to 0, it returns an empty string.
 func Encode(lat, lon float64, precision int) string {
 	precision = min(max(precision, 0), encodeMaxPrecision)
 	var buf [encodeMaxPrecision]byte


### PR DESCRIPTION
The `Encode` doc comment documented the maximum supported precision (32) but was silent on what happens when `precision <= 0`.

This adds a line documenting that `Encode` returns an empty string when precision is less than or equal to 0, which is the actual behavior since precision is clamped to `[0, 32]`.

The behavior is already covered by `TestEncodePrecisionZero` and `TestEncodePrecisionNegative`.